### PR TITLE
Fix hard dependency on devtools [#26]

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-aop")
-    implementation("org.springframework.boot:spring-boot-devtools")
+    compileOnly("org.springframework.boot:spring-boot-devtools")
     implementation("io.projectreactor:reactor-core")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/core/src/main/kotlin/de/tschuehly/spring/viewcomponent/core/ViewComponentAutoConfiguration.kt
+++ b/core/src/main/kotlin/de/tschuehly/spring/viewcomponent/core/ViewComponentAutoConfiguration.kt
@@ -1,6 +1,5 @@
 package de.tschuehly.spring.viewcomponent.core
 
-import de.tschuehly.spring.viewcomponent.core.component.ViewComponent
 import de.tschuehly.spring.viewcomponent.core.component.ViewComponentProperties
 import de.tschuehly.spring.viewcomponent.core.processor.ViewComponentChangeListener
 import org.slf4j.Logger
@@ -36,11 +35,17 @@ class ViewComponentAutoConfiguration {
             fileSystemWatcher.addSourceDirectory(templateRoot)
             logger.info("Watching for template changes at: ${viewComponentDirectory.absoluteFile.path}")
             logger.info("Watching for template changes at: ${templateRoot.absoluteFile.path}")
-            fileSystemWatcher.addListener(
-                ViewComponentChangeListener(
-                    applicationContext
+            try {
+                fileSystemWatcher.addListener(
+                    ViewComponentChangeListener(
+                        applicationContext
+                    )
                 )
-            )
+            } catch (ex: ClassNotFoundException) {
+                logger.error("In order to use hot-reload function, spring dev tools needed", ex)
+            } catch (ex: NoClassDefFoundError) {
+                logger.error("In order to use hot-reload function, spring dev tools needed", ex)
+            }
             fileSystemWatcher.start()
             return fileSystemWatcher
         }


### PR DESCRIPTION
### Changelist
- build.gradle.kts in spring-vie-component-core
- ViewComponentAutoConfiguration
spring-dev-tools is not hard dependency now

### Test
In kts-example, if `spring.view-component.local-development=true` and `spring-dev-tools` is not in classpath, it throws error in bean creation time.
```log
java.lang.IllegalStateException: Error processing condition on de.tschuehly.spring.viewcomponent.kte.KteConfiguration.kteNonLocalTemplateEngine
	at org.springframework.boot.autoconfigure.condition.SpringBootCondition.matches(SpringBootCondition.java:60) ~[spring-boot-autoconfigure-3.2.4.jar:3.2.4]
	at org.springframework.context.annotation.ConditionEvaluator.shouldSkip(ConditionEvaluator.java:108) ~[spring-context-6.1.5.jar:6.1.5]
	at org.springframework.context.annotation.ConfigurationClassBeanDefinitionReader.loadBeanDefinitionsForBeanMethod(ConfigurationClassBeanDefinitionReader.java:183) ~[spring-context-6.1.5.jar:6.1.5]
	at org.springframework.context.annotation.ConfigurationClassBeanDefinitionReader.loadBeanDefinitionsForConfigurationClass(ConfigurationClassBeanDefinitionReader.java:144) ~[spring-context-6.1.5.jar:6.1.5]
	at org.springframework.context.annotation.ConfigurationClassBeanDefinitionReader.loadBeanDefinitions(ConfigurationClassBeanDefinitionReader.java:120) ~[spring-context-6.1.5.jar:6.1.5]
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.processConfigBeanDefinitions(ConfigurationClassPostProcessor.java:428) ~[spring-context-6.1.5.jar:6.1.5]
	at org.springframework.context.annotation.ConfigurationClassPostProcessor.postProcessBeanDefinitionRegistry(ConfigurationClassPostProcessor.java:289) ~[spring-context-6.1.5.jar:6.1.5]
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanDefinitionRegistryPostProcessors(PostProcessorRegistrationDelegate.java:349) ~[spring-context-6.1.5.jar:6.1.5]
	at org.springframework.context.support.PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors(PostProcessorRegistrationDelegate.java:118) ~[spring-context-6.1.5.jar:6.1.5]
	at org.springframework.context.support.AbstractApplicationContext.invokeBeanFactoryPostProcessors(AbstractApplicationContext.java:788) ~[spring-context-6.1.5.jar:6.1.5]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:606) ~[spring-context-6.1.5.jar:6.1.5]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) ~[spring-boot-3.2.4.jar:3.2.4]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:754) ~[spring-boot-3.2.4.jar:3.2.4]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:456) ~[spring-boot-3.2.4.jar:3.2.4]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:334) ~[spring-boot-3.2.4.jar:3.2.4]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1354) ~[spring-boot-3.2.4.jar:3.2.4]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1343) ~[spring-boot-3.2.4.jar:3.2.4]
	at de.tschuehly.kteviewcomponentexample.KteExampleKt.main(KteExample.kt:14) ~[main/:na]
Caused by: java.lang.IllegalStateException: Failed to introspect Class [de.tschuehly.spring.viewcomponent.core.ViewComponentAutoConfiguration$LocalDevConfig] from ClassLoader [jdk.internal.loader.ClassLoaders$AppClassLoader@36baf30c]
	at org.springframework.util.ReflectionUtils.getDeclaredMethods(ReflectionUtils.java:483) ~[spring-core-6.1.5.jar:6.1.5]
	at org.springframework.util.ReflectionUtils.doWithMethods(ReflectionUtils.java:360) ~[spring-core-6.1.5.jar:6.1.5]
	at org.springframework.util.ReflectionUtils.getUniqueDeclaredMethods(ReflectionUtils.java:417) ~[spring-core-6.1.5.jar:6.1.5]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.lambda$getTypeForFactoryMethod$1(AbstractAutowireCapableBeanFactory.java:750) ~[spring-beans-6.1.5.jar:6.1.5]
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1740) ~[na:na]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.getTypeForFactoryMethod(AbstractAutowireCapableBeanFactory.java:749) ~[spring-beans-6.1.5.jar:6.1.5]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.determineTargetType(AbstractAutowireCapableBeanFactory.java:682) ~[spring-beans-6.1.5.jar:6.1.5]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.predictBeanType(AbstractAutowireCapableBeanFactory.java:653) ~[spring-beans-6.1.5.jar:6.1.5]
	at org.springframework.beans.factory.support.AbstractBeanFactory.isFactoryBean(AbstractBeanFactory.java:1645) ~[spring-beans-6.1.5.jar:6.1.5]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doGetBeanNamesForType(DefaultListableBeanFactory.java:562) ~[spring-beans-6.1.5.jar:6.1.5]
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBeanNamesForType(DefaultListableBeanFactory.java:534) ~[spring-beans-6.1.5.jar:6.1.5]
	at org.springframework.boot.autoconfigure.condition.OnBeanCondition.collectBeanNamesForType(OnBeanCondition.java:247) ~[spring-boot-autoconfigure-3.2.4.jar:3.2.4]
	at org.springframework.boot.autoconfigure.condition.OnBeanCondition.getBeanNamesForType(OnBeanCondition.java:240) ~[spring-boot-autoconfigure-3.2.4.jar:3.2.4]
	at org.springframework.boot.autoconfigure.condition.OnBeanCondition.getBeanNamesForType(OnBeanCondition.java:230) ~[spring-boot-autoconfigure-3.2.4.jar:3.2.4]
	at org.springframework.boot.autoconfigure.condition.OnBeanCondition.getMatchingBeans(OnBeanCondition.java:183) ~[spring-boot-autoconfigure-3.2.4.jar:3.2.4]
	at org.springframework.boot.autoconfigure.condition.OnBeanCondition.getMatchOutcome(OnBeanCondition.java:158) ~[spring-boot-autoconfigure-3.2.4.jar:3.2.4]
	at org.springframework.boot.autoconfigure.condition.SpringBootCondition.matches(SpringBootCondition.java:47) ~[spring-boot-autoconfigure-3.2.4.jar:3.2.4]
	... 17 common frames omitted
Caused by: java.lang.NoClassDefFoundError: org/springframework/boot/devtools/filewatch/FileSystemWatcher
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method) ~[na:na]
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3578) ~[na:na]
	at java.base/java.lang.Class.getDeclaredMethods(Class.java:2676) ~[na:na]
	at org.springframework.util.ReflectionUtils.getDeclaredMethods(ReflectionUtils.java:465) ~[spring-core-6.1.5.jar:6.1.5]
	... 33 common frames omitted
Caused by: java.lang.ClassNotFoundException: org.springframework.boot.devtools.filewatch.FileSystemWatcher
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641) ~[na:na]
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188) ~[na:na]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[na:na]
	... 37 common frames omitted
```

But even if  `spring-dev-tools` is not in classpath but `spring.view-component.local-development=false`, it doesn't throws error and example page runs well